### PR TITLE
Expose overhead and HKDF functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,12 @@ file(GLOB_RECURSE LIB_SOURCES CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src
 
 add_library(${LIB_NAME} ${LIB_HEADERS} ${LIB_SOURCES})
 add_dependencies(${LIB_NAME} gsl)
-target_link_libraries(${LIB_NAME} PRIVATE gsl OpenSSL::Crypto)
+target_link_libraries(${LIB_NAME} 
+  PUBLIC
+    gsl
+  PRIVATE 
+    OpenSSL::Crypto
+)
 target_include_directories(${LIB_NAME}
   PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>

--- a/include/sframe/crypto.h
+++ b/include/sframe/crypto.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <sframe/sframe.h>
+
+namespace sframe {
+
+// This method is exposed to callers so that they can allocate a ciphertext
+// buffer of the appropriate size to encrypt a given plaintext.
+size_t
+overhead(CipherSuite suite);
+
+// These methods are exposed so that callers can derive values for input to
+// SFrame
+bytes
+hkdf_extract(CipherSuite suite, const bytes& salt, const bytes& ikm);
+
+bytes
+hkdf_expand(CipherSuite suite,
+            const bytes& secret,
+            const bytes& info,
+            size_t size);
+
+} // namespace sframe

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -1,4 +1,4 @@
-#include "crypto.h"
+#include "crypto_priv.h"
 
 #include <openssl/err.h>
 #include <openssl/evp.h>

--- a/src/crypto_priv.h
+++ b/src/crypto_priv.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <openssl/hmac.h>
-#include <sframe/sframe.h>
+#include <sframe/crypto.h>
 
 #include <array>
 
@@ -40,21 +40,9 @@ struct HMAC
   std::array<uint8_t, EVP_MAX_MD_SIZE> md;
 };
 
-bytes
-hkdf_extract(CipherSuite suite, const bytes& salt, const bytes& ikm);
-
-bytes
-hkdf_expand(CipherSuite suite,
-            const bytes& secret,
-            const bytes& info,
-            size_t size);
-
 ///
 /// AEAD Algorithms
 ///
-
-size_t
-overhead(CipherSuite suite);
 
 output_bytes
 seal(CipherSuite suite,

--- a/src/sframe.cpp
+++ b/src/sframe.cpp
@@ -1,6 +1,6 @@
 #include <sframe/sframe.h>
 
-#include "crypto.h"
+#include "crypto_priv.h"
 #include "header.h"
 
 #include <algorithm>


### PR DESCRIPTION
While hacking on day 1 of the offsite, @paulej noticed that the `overhead()` function needs to be exposed to callers to facilitate precise allocations.  (As opposed to over-allocating and then truncating, as we do now.)

I also expect that we are going to need to do some HKDF to derive keys, so I exposed these as well.